### PR TITLE
Fix incorrect header for VOICEVOX synthesis

### DIFF
--- a/auditory_learning/utils/voice_utils.py
+++ b/auditory_learning/utils/voice_utils.py
@@ -57,7 +57,7 @@ class VoiceVoxSpeaker:
 
         synthesis_response = httpx.post(
             f"{self.url}/synthesis?speaker={self.speaker_id}",
-            headers={"Context-Type": "application/json"},
+            headers={"Content-Type": "application/json"},
             data=synthesis_config.as_bytes(),
         )
         if not (200 <= synthesis_response.status_code < 300):


### PR DESCRIPTION
## Summary
- correct HTTP header name when requesting VOICEVOX synthesis

## Testing
- `make format`
- `make test` *(fails: no tests collected)*

------
https://chatgpt.com/codex/tasks/task_e_68422b63f5808321b5f244aad60c0ebb